### PR TITLE
Fix panic at launch when current song does not have lyrics

### DIFF
--- a/internal/client/mpdclient.go
+++ b/internal/client/mpdclient.go
@@ -165,7 +165,9 @@ func (c *MPDClient) lyrics(song Song) *lyrics.Lyrics {
 	old := c.id.Swap(id)
 	if id != old {
 		lrc := lyrics.ForFile(filepath.Join(*c.lyricsDir, filepath.FromSlash(song.File())))
-		lrc.Sort()
+		if lrc != nil {
+			lrc.Sort()
+		}
 		c.lrc = lrc
 	}
 	return c.lrc


### PR DESCRIPTION
When launching mpdlrc while playing a song without associated lrc file, the following panic occurs:

```sh
$ mpdlrc
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x58e454]

goroutine 1 [running]:
github.com/env25/mpdlrc/internal/lyrics.(*Lyrics).check(...)
	/home/denis/Clone/github.com/eNV25/mpdlrc/internal/lyrics/lyrics.go:20
github.com/env25/mpdlrc/internal/lyrics.(*Lyrics).Sort(...)
	/home/denis/Clone/github.com/eNV25/mpdlrc/internal/lyrics/lyrics.go:43
github.com/env25/mpdlrc/internal/client.(*MPDClient).lyrics(0xc000227700, {0x65fc90, 0xc0008d0000})
	/home/denis/Clone/github.com/eNV25/mpdlrc/internal/client/mpdclient.go:168 +0xf4
github.com/env25/mpdlrc/internal/client.(*MPDClient).Data(0xc000227700)
	/home/denis/Clone/github.com/eNV25/mpdlrc/internal/client/mpdclient.go:145 +0x558
github.com/env25/mpdlrc/internal.(*Application).updateResize(0xc000278000, {0x65ee50, 0xc00009c050}, {0x65e188, 0xc00022e000}, 0x105, 0x6e)
	/home/denis/Clone/github.com/eNV25/mpdlrc/internal/app.go:106 +0x15c
github.com/env25/mpdlrc/internal.(*Application).update(0xc000278000, {0x65ee50, 0xc00009c050}, {0x65e188?, 0xc00022e000})
	/home/denis/Clone/github.com/eNV25/mpdlrc/internal/app.go:83 +0x479
github.com/env25/mpdlrc/internal.(*Application).Run(0xc000278000, {0x65ede0, 0x851380})
	/home/denis/Clone/github.com/eNV25/mpdlrc/internal/app.go:145 +0x4f0
main.maine()
	/home/denis/Clone/github.com/eNV25/mpdlrc/main.go:81 +0x27e
main.main()
	/home/denis/Clone/github.com/eNV25/mpdlrc/main.go:98 +0x5a
```

I fix it by bypassing the call to `lrc.Sort()` when `lrc` is `nil`.